### PR TITLE
Remove vagrant provision key from image

### DIFF
--- a/coreos.json
+++ b/coreos.json
@@ -20,10 +20,10 @@
             "iso_url": "http://{{user `coreos_channel`}}.release.core-os.net/amd64-usr/{{user `coreos_version`}}/coreos_production_iso_image.iso",
             "output_directory": "builds/coreos-{{user `coreos_channel`}}-{{user `coreos_version`}}-qemu",
             "qemuargs": [
-                [
-                    "-m",
-                    "{{user `memory`}}"
-                ]
+                ["-m", "{{user `memory`}}"],
+                ["-fsdev", "local,id=conf,security_model=none,readonly,path={{pwd}}/files"],
+                ["-device", "virtio-9p-pci,fsdev=conf,mount_tag=config-2"],
+                ["-device", "virtio-net,netdev=user.0"]
             ],
             "shutdown_command": "sudo -S shutdown -P now",
             "ssh_private_key_file": "files/vagrant_id_rsa",
@@ -40,7 +40,9 @@
             "type": "file"
         },
         {
-            "environment_vars": [],
+            "environment_vars": [
+                "REMOVE_VAGRANT_KEY={{user `remove_vagrant_key`}}"
+            ],
             "scripts": [
                 "scripts/oem.sh",
                 "scripts/cleanup.sh"
@@ -57,6 +59,7 @@
         "install_target": "/dev/vda",
         "iso_checksum": "<not-set>",
         "iso_checksum_type": "md5",
-        "memory": "1024"
+        "memory": "1024",
+        "remove_vagrant_key": "true"
     }
 }

--- a/coreos.json
+++ b/coreos.json
@@ -1,60 +1,62 @@
 {
-    "description": "CoreOS image for OpenNebula",
-    "variables": {
-	"accelerator": "kvm",
-	"boot_wait": "60s",
-	"coreos_channel": "alpha",
-	"coreos_version": "<not-set>",
-	"headless": "false",
-	"install_target": "/dev/vda",
-	"iso_checksum": "<not-set>",
-	"iso_checksum_type": "md5",
-	"memory": "1024"
-    },
     "builders": [
-	{
-	    "type": "qemu",
-	    "iso_url": "http://{{user `coreos_channel`}}.release.core-os.net/amd64-usr/{{user `coreos_version`}}/coreos_production_iso_image.iso",
-	    "iso_checksum": "{{user `iso_checksum`}}",
-	    "iso_checksum_type": "{{user `iso_checksum_type`}}",
-	    "ssh_username": "core",
-	    "accelerator": "{{user `accelerator`}}",
-	    "boot_command": [
-		"sudo -i<enter>",
-		"systemctl stop sshd.socket<enter>",
-		"wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/install.yml<enter>",
-		"coreos-install -d {{user `install_target`}} -C {{user `coreos_channel`}} -c install.yml<enter>",
-		"reboot<enter>"
-	    ],
-	    "boot_wait": "{{user `boot_wait`}}",
-	    "disk_size": 10240,
-	    "format": "qcow2",
-	    "headless": "{{user `headless`}}",
-	    "http_directory": "files",
-	    "output_directory": "builds/coreos-{{user `coreos_channel`}}-{{user `coreos_version`}}-qemu",
-	    "qemuargs": [
-		["-m", "{{user `memory`}}"]
-	    ],
-	    "shutdown_command": "sudo -S shutdown -P now",
-	    "communicator": "ssh",
-	    "ssh_private_key_file": "files/vagrant_id_rsa",
-	    "ssh_timeout": "60m",
-	    "ssh_username": "core"
-	}
+        {
+            "accelerator": "{{user `accelerator`}}",
+            "boot_command": [
+                "sudo -i<enter>",
+                "systemctl stop sshd.socket<enter>",
+                "wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/install.yml<enter>",
+                "coreos-install -d {{user `install_target`}} -C {{user `coreos_channel`}} -c install.yml<enter>",
+                "reboot<enter>"
+            ],
+            "boot_wait": "{{user `boot_wait`}}",
+            "communicator": "ssh",
+            "disk_size": 10240,
+            "format": "qcow2",
+            "headless": "{{user `headless`}}",
+            "http_directory": "files",
+            "iso_checksum": "{{user `iso_checksum`}}",
+            "iso_checksum_type": "{{user `iso_checksum_type`}}",
+            "iso_url": "http://{{user `coreos_channel`}}.release.core-os.net/amd64-usr/{{user `coreos_version`}}/coreos_production_iso_image.iso",
+            "output_directory": "builds/coreos-{{user `coreos_channel`}}-{{user `coreos_version`}}-qemu",
+            "qemuargs": [
+                [
+                    "-m",
+                    "{{user `memory`}}"
+                ]
+            ],
+            "shutdown_command": "sudo -S shutdown -P now",
+            "ssh_private_key_file": "files/vagrant_id_rsa",
+            "ssh_timeout": "60m",
+            "ssh_username": "core",
+            "type": "qemu"
+        }
     ],
+    "description": "CoreOS image for OpenNebula",
     "provisioners": [
-	{
-	    "type": "file",
-	    "source": "oem/",
-	    "destination": "/home/core"
-	},
-	{
-	    "type": "shell",
-	    "environment_vars": [],
-	    "scripts": [
-		"scripts/oem.sh",
-		"scripts/cleanup.sh"
-	    ]
-	}
-    ]
+        {
+            "destination": "/home/core",
+            "source": "oem/",
+            "type": "file"
+        },
+        {
+            "environment_vars": [],
+            "scripts": [
+                "scripts/oem.sh",
+                "scripts/cleanup.sh"
+            ],
+            "type": "shell"
+        }
+    ],
+    "variables": {
+        "accelerator": "kvm",
+        "boot_wait": "60s",
+        "coreos_channel": "alpha",
+        "coreos_version": "<not-set>",
+        "headless": "false",
+        "install_target": "/dev/vda",
+        "iso_checksum": "<not-set>",
+        "iso_checksum_type": "md5",
+        "memory": "1024"
+    }
 }

--- a/files/install.yml
+++ b/files/install.yml
@@ -83,9 +83,3 @@ coreos:
     version-id: 0.1
     home-url: http://github.com/carletes/coreos-opennebula-image
     bug-report-url: http://github.com/carletes/coreos-opennebula-image
-
-ssh_authorized_keys:
-  # Set Vagrant's insecure SSH public key for second stage of
-  # installation (it will be overwritten with the user's SSH key by
-  # `opennebula-ssh-key.service`).
-  - ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key

--- a/files/openstack/latest/user_data
+++ b/files/openstack/latest/user_data
@@ -1,0 +1,7 @@
+#cloud-config
+
+ssh_authorized_keys:
+  # Set Vagrant's insecure SSH public key for second stage of
+  # provisioning.
+  # The key will be cleared after the provisioning.
+  - ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key

--- a/oem/coreos-setup-environment
+++ b/oem/coreos-setup-environment
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ENV=$1
 

--- a/oem/opennebula-cloudinit
+++ b/oem/opennebula-cloudinit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -n "$DEBUG" ] ; then
     set -x
@@ -12,8 +12,8 @@ echo "Running cloud-init with user data"
 
 if [ -z "$USER_DATA" ] ; then
     if [ -z "$EC2_USER_DATA" ] ; then
-	echo "No user data, leaving."
-	exit 0
+        echo "No user data, leaving."
+        exit 0
     fi
     USER_DATA="$(echo $EC2_USER_DATA | base64 -d)"
 fi

--- a/oem/opennebula-common
+++ b/oem/opennebula-common
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -n "$DEBUG" ] ; then
     set -x

--- a/oem/opennebula-hostname
+++ b/oem/opennebula-hostname
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -n "$DEBUG" ] ; then
     set -x
@@ -11,38 +11,38 @@ here="$(cd $(dirname $0) && pwd)"
 echo "Setting host name"
 
 if [ -z "$SET_HOSTNAME" ] ; then
-    # No host name provided by user. Try guessing it.
+# No host name provided by user. Try guessing it.
 
-    if [ "$DNS_HOSTNAME" = "YES" ] ; then
-	# Try DNS.
-	for i in $(seq 0 9) ; do
-	    ip_var="ETH${i}_IP"
-	    if [ -n "${!ip_var}" ] ; then
-		hostname="$(host ${!ip_var})"
-		if [ "$?" = "0" ] ; then
-		    SET_HOSTNAME=$hostname
-		    break
-		fi
-	    fi
-	done
+if [ "$DNS_HOSTNAME" = "YES" ] ; then
+# Try DNS.
+for i in $(seq 0 9) ; do
+    ip_var="ETH${i}_IP"
+    if [ -n "${!ip_var}" ] ; then
+        hostname="$(host ${!ip_var})"
+        if [ "$?" = "0" ] ; then
+            SET_HOSTNAME=$hostname
+            break
+        fi
     fi
+done
+fi
 
-    if [ -z "$SET_HOSTNAME" ] ; then
-	# DNS lookup did not work (or lookup was not requested), try
-	# MAC addresses.
-	for i in $(seq 0 9) ; do
-	    mac_var="ETH${i}_MAC"
-	    if [ -n "${!mac_var}" ] ; then
-		SET_HOSTNAME="coreos-$(echo "${!mac_var}" | tr : -)"
-		break
-	    fi
-	done
+if [ -z "$SET_HOSTNAME" ] ; then
+# DNS lookup did not work (or lookup was not requested), try
+# MAC addresses.
+for i in $(seq 0 9) ; do
+    mac_var="ETH${i}_MAC"
+    if [ -n "${!mac_var}" ] ; then
+        SET_HOSTNAME="coreos-$(echo "${!mac_var}" | tr : -)"
+        break
     fi
+done
+fi
 
-    if [ -z "$SET_HOSTNAME" ] ; then
-	# No MAC addresses found
-	SET_HOSTNAME="localhost"
-    fi
+if [ -z "$SET_HOSTNAME" ] ; then
+# No MAC addresses found
+SET_HOSTNAME="localhost"
+fi
 
 fi
 

--- a/oem/opennebula-network
+++ b/oem/opennebula-network
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -n "$DEBUG" ] ; then
     set -x
@@ -13,135 +13,136 @@ function setup_interface() {
 
     network_mask_var="${iface}_MASK"
     case "${!network_mask_var}" in
-	"")
-	    ;;
-	128.0.0.0)
-	    netmask=1
-	    ;;
+    "")
+        ;;
 
-	192.0.0.0)
-	    netmask=2
-	    ;;
+    128.0.0.0)
+        netmask=1
+        ;;
 
-	224.0.0.0)
-	    netmask=3
-	    ;;
+    192.0.0.0)
+        netmask=2
+        ;;
 
-	240.0.0.0)
-	    netmask=4
-	    ;;
+    224.0.0.0)
+        netmask=3
+        ;;
 
-	248.0.0.0)
-	    netmask=5
-	    ;;
+    240.0.0.0)
+        netmask=4
+        ;;
 
-	252.0.0.0)
-	    netmask=6
-	    ;;
+    248.0.0.0)
+        netmask=5
+        ;;
 
-	254.0.0.0)
-	    netmask=7
-	    ;;
+    252.0.0.0)
+        netmask=6
+        ;;
 
-	255.0.0.0)
-	    netmask=8
-	    ;;
+    254.0.0.0)
+        netmask=7
+        ;;
 
-	255.128.0.0)
-	    netmask=9
-	    ;;
+    255.0.0.0)
+        netmask=8
+        ;;
 
-	255.192.0.0)
-	    netmask=10
-	    ;;
+    255.128.0.0)
+        netmask=9
+        ;;
 
-	255.224.0.0)
-	    netmask=11
-	    ;;
+    255.192.0.0)
+        netmask=10
+        ;;
 
-	255.240.0.0)
-	    netmask=12
-	    ;;
+    255.224.0.0)
+        netmask=11
+        ;;
 
-	255.248.0.0)
-	    netmask=13
-	    ;;
+    255.240.0.0)
+        netmask=12
+        ;;
 
-	255.252.0.0)
-	    netmask=14
-	    ;;
+    255.248.0.0)
+        netmask=13
+        ;;
 
-	255.254.0.0)
-	    netmask=15
-	    ;;
+    255.252.0.0)
+        netmask=14
+        ;;
 
-	255.255.0.0)
-	    netmask=16
-	    ;;
+    255.254.0.0)
+        netmask=15
+        ;;
 
-	255.255.128.0)
-	    netmask=17
-	    ;;
+    255.255.0.0)
+        netmask=16
+        ;;
 
-	255.255.192.0)
-	    netmask=18
-	    ;;
+    255.255.128.0)
+        netmask=17
+        ;;
 
-	255.255.224.0)
-	    netmask=19
-	    ;;
+    255.255.192.0)
+        netmask=18
+        ;;
 
-	255.255.240.0)
-	    netmask=20
-	    ;;
+    255.255.224.0)
+        netmask=19
+        ;;
 
-	255.255.248.0)
-	    netmask=21
-	    ;;
+    255.255.240.0)
+        netmask=20
+        ;;
 
-	255.255.252.0)
-	    netmask=22
-	    ;;
+    255.255.248.0)
+        netmask=21
+        ;;
 
-	255.255.254.0)
-	    netmask=23
-	    ;;
+    255.255.252.0)
+        netmask=22
+        ;;
 
-	255.255.255.0)
-	    netmask=24
-	    ;;
+    255.255.254.0)
+        netmask=23
+        ;;
 
-	255.255.255.128)
-	    netmask=25
-	    ;;
+    255.255.255.0)
+        netmask=24
+        ;;
 
-	255.255.255.192)
-	    netmask=26
-	    ;;
+    255.255.255.128)
+        netmask=25
+        ;;
 
-	255.255.255.224)
-	    netmask=27
-	    ;;
+    255.255.255.192)
+        netmask=26
+        ;;
 
-	255.255.255.240)
-	    netmask=28
-	    ;;
+    255.255.255.224)
+        netmask=27
+        ;;
 
-	255.255.255.248)
-	    netmask=29
-	    ;;
+    255.255.255.240)
+        netmask=28
+        ;;
 
-	255.255.255.252)
-	    netmask=30
-	    ;;
+    255.255.255.248)
+        netmask=29
+        ;;
 
-	255.255.255.254)
-	    netmask=31
-	    ;;
-	*)
-	    echo "Unsupported netmask ${!network_mask_var}"
-	    exit 1
-	    ;;
+    255.255.255.252)
+        netmask=30
+        ;;
+
+    255.255.255.254)
+        netmask=31
+        ;;
+    *)
+        echo "Unsupported netmask ${!network_mask_var}"
+        exit 1
+        ;;
     esac
 
     ip_address_var="${iface}_IP"
@@ -151,7 +152,7 @@ function setup_interface() {
 
     network_conf="/etc/systemd/network/99-opennebula-$(echo ${!mac_address_var} | tr : -).network"
     if [ -n "$DEBUG" ] ; then
-	network_conf="/tmp/opennebula.network"
+        network_conf="/tmp/opennebula.network"
     fi
 
     echo "${!mac_address_var}: IP Address is ${!ip_address_var}/$netmask"
@@ -170,20 +171,20 @@ EOT
 DHCP=no
 Address=${!ip_address_var}/$netmask
 EOT
-	gateway="${!gateway_var}"
-	if [ -n "$gateway" ] ; then
-	    cat >> $network_conf <<EOT
+        gateway="${!gateway_var}"
+        if [ -n "$gateway" ] ; then
+            cat >> $network_conf <<EOT
 Gateway=$gateway
 EOT
-	fi
-	dns="${!dns_var}"
-	if [ -n "$dns" ] ; then
-	    cat >> $network_conf <<EOT
+        fi
+        dns="${!dns_var}"
+        if [ -n "$dns" ] ; then
+            cat >> $network_conf <<EOT
 DNS=$dns
 EOT
-	fi
+        fi
     else
-	cat >> $network_conf <<EOF
+        cat >> $network_conf <<EOF
 DHCP=yes
 EOF
     fi
@@ -200,6 +201,6 @@ fi
 for iface in ETH0 ETH1 ETH2 ETH3 ETH4 ETH4 ETH6 ETH7 ETH8 ETH9 ; do
     mac_address_var="${iface}_MAC"
     if [ -n "${!mac_address_var}" ] ; then
-	setup_interface $iface
+        setup_interface $iface
     fi
 done

--- a/oem/opennebula-ssh-key
+++ b/oem/opennebula-ssh-key
@@ -8,5 +8,10 @@ here="$(cd $(dirname $0) && pwd)"
 
 . $here/opennebula-common
 
+if [ -z "$SSH_PUBLIC_KEY" ] ; then
+  echo "No SSH public key, leaving."
+  exit 0
+fi
+
 echo "Adding OpenNebula SSH public key"
 echo $SSH_PUBLIC_KEY | update-ssh-keys -u core -a coreos-cloudinit

--- a/oem/opennebula-ssh-key
+++ b/oem/opennebula-ssh-key
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -n "$DEBUG" ] ; then
     set -x
@@ -9,8 +9,8 @@ here="$(cd $(dirname $0) && pwd)"
 . $here/opennebula-common
 
 if [ -z "$SSH_PUBLIC_KEY" ] ; then
-  echo "No SSH public key, leaving."
-  exit 0
+    echo "No SSH public key, leaving."
+    exit 0
 fi
 
 echo "Adding OpenNebula SSH public key"

--- a/packer.sh
+++ b/packer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -x
 

--- a/packer.sh
+++ b/packer.sh
@@ -10,6 +10,7 @@ else
     boot_wait="120s"
 fi
 headless="${HEADLESS:-false}"
+remove_vagrant_key="${REMOVE_VAGRANT_KEY:-true}"
 
 exec packer $1 \
      -var accelerator=$accelerator \
@@ -18,4 +19,5 @@ exec packer $1 \
      -var coreos_channel=$COREOS_CHANNEL \
      -var coreos_version=$COREOS_VERSION \
      -var iso_checksum=$COREOS_MD5_CHECKSUM \
+     -var remove_vagrant_key=$remove_vagrant_key \
      $2

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Remove SSH server keys from image.
-
+# Keys will be regenerated on first boot => sshd-keygen.service
 sudo rm -f /etc/ssh/ssh_host_*_key
 sudo rm -f /etc/ssh/ssh_host_*_key.pub

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -4,3 +4,10 @@
 # Keys will be regenerated on first boot => sshd-keygen.service
 sudo rm -f /etc/ssh/ssh_host_*_key
 sudo rm -f /etc/ssh/ssh_host_*_key.pub
+
+if [ "$REMOVE_VAGRANT_KEY" = "true" ] || [ "$REMOVE_VAGRANT_KEY" = "1" ]; then
+    # Remove packer public key.
+    # update-ssh-keys won't update the authorized_keys if no key under authorized_keys.d were found.
+    # Truncate authorized_keys instead.
+    sudo update-ssh-keys -u core -d oem-provisioner || sudo truncate -s0 $(getent passwd 'core' | cut -d: -f6)/.ssh/authorized_keys
+fi

--- a/scripts/oem.sh
+++ b/scripts/oem.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Put the OEM `cloud-config` dependent scripts in the right place.
 sudo mkdir /usr/share/oem/bin


### PR DESCRIPTION
The vagrant public key was preserved and restored on every boot
if no the context variable SSH_PUBLIC_KEY was missing.
The initial install.yml file and the vagrant public key
are stored under /var/lib/coreos-install/user_data. This files gets
applied on every reboot.
To bring in the public key for provisioning the following trick
is used:
By adding the custom qemu arguments a virtual disk is mounted
and processed by CoreOS after the first boot.
https://coreos.com/os/docs/latest/config-drive.html

I also cleaned up the bash scripts. Mix of spaces and tabs.
