### PR TITLE
Minor improvement: Image compression is options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ PACKER_IMAGE_DIR = builds/coreos-$(COREOS_CHANNEL)-$(COREOS_VERSION)-qemu
 PACKER_IMAGE_NAME = coreos-$(COREOS_CHANNEL)-$(COREOS_VERSION)
 PACKER_IMAGE = $(PACKER_IMAGE_DIR)/$(PACKER_IMAGE_NAME)
 PACKER_IMAGE_BZ2 = $(PACKER_IMAGE).bz2
+PACKER_IMAGE_COMPRESSION = false
 PACKER_IMAGE_DEPS = \
 	coreos.json \
 	packer.sh \
@@ -37,7 +38,9 @@ $(PACKER_IMAGE): $(PACKER_IMAGE_DEPS)
 	  PACKER_LOG=1 \
 	    ./packer.sh build coreos.json
 	mv $(PACKER_IMAGE_DIR)/packer-qemu $(PACKER_IMAGE)
+ifeq ($(PACKER_IMAGE_COMPRESSION), true)
 	bzip2 -9vk $(PACKER_IMAGE)
+endif
 	echo "Image file $(PACKER_IMAGE) ready"
 
 .PHONY: appliance register clean

--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ parameters to `make`:
 	Image file builds/coreos-stable-899.13.0-qemu/packer-qemu ready
 	$
 
+You may enable compression to generate a compressed bz2 image by passing
+the appropriate parameters to `make`:
+
+    $ make PACKER_IMAGE_COMPRESSION=true
+    [..]
+    bzip2 -9vk builds/coreos-alpha-991.0.0-qemu/packer-qemu
+    [..]
+    Image file builds/coreos-alpha-991.0.0-qemu/packer-qemu ready
+    $
 
 ## Registering the image with OpenNebula
 


### PR DESCRIPTION
OpenNebula warn about compressed images.
Quote from http://docs.opennebula.org/4.12/user/references/img_template.html:

```
Be careful when PATH points to a compressed bz2 image, since although it will work, OpenNebula will not calculate its size correctly.
```

For this reason and to save time when building an image disable compression by default. But allow to enable image compression with a
new make paramter.
