### PR TITLE
Fix issue with service opennebula-cloudinit not running

### DIFF
--- a/files/install.yml
+++ b/files/install.yml
@@ -69,8 +69,8 @@ coreos:
       content: |
         [Unit]
         Description=User-provided cloud-init setup
-        Requires=network.target,coreos-setup-environment.service
-        After=network.target,coreos-setup-environment.service
+        Requires=network.target coreos-setup-environment.service
+        After=network.target coreos-setup-environment.service
 
         [Service]
         Type=oneshot


### PR DESCRIPTION
The [Requires=](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Requires=) option supports to define multiple requirements.

Quote:

> This option may be specified more than once or multiple space-separated units
> may be specified in one option in which case requirement dependencies for all
> listed names will be created.

A ',' is invalid and newer versions of systemd fail because the target name is
'network.target,coreos-setup-environment.service'.

The same applies to the Before= and After= options.
